### PR TITLE
add space between disabled and placeholder

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -238,7 +238,7 @@ var inputFieldTemplate = function (type) {
       '<%= (node.readOnly ? " readonly=\'readonly\'" : "") %>' +
       '<%= (node.schemaElement && node.schemaElement.maxLength ? " maxlength=\'" + node.schemaElement.maxLength + "\'" : "") %>' +
       '<%= (node.schemaElement && node.schemaElement.required && (node.schemaElement.type !== "boolean") ? " required=\'required\'" : "") %>' +
-      '<%= (node.placeholder? "placeholder=" + \'"\' + escape(node.placeholder) + \'"\' : "")%>' +
+      '<%= (node.placeholder? " placeholder=" + \'"\' + escape(node.placeholder) + \'"\' : "")%>' +
       ' />',
     'fieldtemplate': true,
     'inputfield': true


### PR DESCRIPTION
When there is a disabled field and a placeholder they get concatenated: disabledplaceholder

The disabled is just outside of this diffs view, my definition happend to have none of the options inbetween.