### PR TITLE
Add space character to placeholder string

### DIFF
--- a/lib/jsonform.js
+++ b/lib/jsonform.js
@@ -238,7 +238,7 @@ var inputFieldTemplate = function (type) {
       '<%= (node.readOnly ? " readonly=\'readonly\'" : "") %>' +
       '<%= (node.schemaElement && node.schemaElement.maxLength ? " maxlength=\'" + node.schemaElement.maxLength + "\'" : "") %>' +
       '<%= (node.schemaElement && node.schemaElement.required && (node.schemaElement.type !== "boolean") ? " required=\'required\'" : "") %>' +
-      '<%= (node.placeholder? "placeholder=" + \'"\' + escape(node.placeholder) + \'"\' : "")%>' +
+      '<%= (node.placeholder? " placeholder=" + \'"\' + escape(node.placeholder) + \'"\' : "")%>' +
       ' />',
     'fieldtemplate': true,
     'inputfield': true
@@ -328,7 +328,7 @@ jsonform.elementTypes = {
       '<%= (node.readOnly ? " readonly=\'readonly\'" : "") %>' +
       '<%= (node.schemaElement && node.schemaElement.maxLength ? " maxlength=\'" + node.schemaElement.maxLength + "\'" : "") %>' +
       '<%= (node.schemaElement && node.schemaElement.required ? " required=\'required\'" : "") %>' +
-      '<%= (node.placeholder? "placeholder=" + \'"\' + escape(node.placeholder) + \'"\' : "")%>' +
+      '<%= (node.placeholder? " placeholder=" + \'"\' + escape(node.placeholder) + \'"\' : "")%>' +
       '><%= value %></textarea>',
     'fieldtemplate': true,
     'inputfield': true
@@ -339,7 +339,7 @@ jsonform.elementTypes = {
       '<%= (node.readOnly ? " readonly=\'readonly\'" : "") %>' +
       '<%= (node.schemaElement && node.schemaElement.maxLength ? " maxlength=\'" + node.schemaElement.maxLength + "\'" : "") %>' +
       '<%= (node.schemaElement && node.schemaElement.required ? " required=\'required\'" : "") %>' +
-      '<%= (node.placeholder? "placeholder=" + \'"\' + escape(node.placeholder) + \'"\' : "")%>' +
+      '<%= (node.placeholder? " placeholder=" + \'"\' + escape(node.placeholder) + \'"\' : "")%>' +
       '><%= value %></textarea>',
     'fieldtemplate': true,
     'inputfield': true,


### PR DESCRIPTION
For each use of the string `"placeholder="`, added a space character at the beginning, i.e.`" placeholder="`.  Without the space, a compounded string is created if you use the 'placeholder' property.
`"form": [
    {
      key: "firstName",
      disabled: true,
      placehoder: "my place"
    }
  ]`

Generates: `<input type="text" disabledplaceholder="my place">` when it should be, `<input type="text" disabled placeholder="my place">`
